### PR TITLE
Fix smartphone layout on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,9 @@
   .hidden{display:none}
   #shopItems button{display:block;width:100%;margin:6px 0;padding:10px;font-size:18px}
 
-  @media (orientation:portrait){
+  @media screen and (max-width:700px){
     canvas{width:90vw;height:90vw}
-    .controller{flex-direction:column;align-items:center;gap:20px;padding:0 0 20px}
+    .controller{flex-direction:column;align-items:center;gap:20px;padding:0 0 calc(env(safe-area-inset-bottom,0px)+20px)}
     .dpad{grid-template-columns:repeat(3,60px);grid-template-rows:repeat(3,60px)}
     .dpad button{width:60px;height:60px;font-size:24px;border-radius:12px}
     .buttons{flex-direction:row}


### PR DESCRIPTION
## Summary
- use width-based media query to resize canvas and controller on small screens
- add safe-area padding so touch controls don't collide with OS bars

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25d92221c8330b5190048058981af