### PR TITLE
Scale minimap to 10% and anchor top-right

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
 <!-- メイン/ミニマップ -->
 <canvas id="view" width="256" height="256"></canvas>
-<canvas id="minimap" width="128" height="128" style="position:fixed;top:10px;right:10px;border:1px solid #20ffe3;border-radius:8px"></canvas>
+<canvas id="minimap" width="128" height="128" style="position:fixed;top:10px;right:10px;border:1px solid #20ffe3;border-radius:8px;transform-origin:top right;transform:scale(0.1);"></canvas>
 
 <!-- コントローラ -->
 <div class="controller">


### PR DESCRIPTION
## Summary
- Shrink minimap via CSS transform to reduce its footprint and keep it fixed to the top-right corner

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2665cd01083308fadb2140091dadc