### PR TITLE
Increase mobile button size for better usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   .dpad button{width:100px;height:100px;font-size:28px;border-radius:20px}
   .buttons{display:flex;flex-direction:column;gap:20px}
   .buttons button{width:120px;height:100px;font-size:22px;border-radius:20px}
-  .btn{background:#0a121d;border:1px solid #1e3550;color:#e5f1ff;font-weight:bold;user-select:none;-webkit-user-select:none;-webkit-touch-callout:none}
+  .btn{background:#0a121d;border:1px solid #1e3550;color:#e5f1ff;font-weight:bold;user-select:none;-webkit-user-select:none;-webkit-touch-callout:none;cursor:pointer}
   .btn:active{transform:translateY(1px)}
   .A{border-color:#20ffe3;color:#20ffe3}
   .B{border-color:#ff4dcb;color:#ff4dcb}
@@ -29,10 +29,12 @@
   @media screen and (max-width:700px){
     canvas{width:90vw;height:90vw}
     .controller{flex-direction:column;align-items:center;gap:20px;padding:0 0 calc(env(safe-area-inset-bottom,0px)+20px)}
-    .dpad{grid-template-columns:repeat(3,60px);grid-template-rows:repeat(3,60px)}
-    .dpad button{width:60px;height:60px;font-size:24px;border-radius:12px}
+    .dpad{grid-template-columns:repeat(3,72px);grid-template-rows:repeat(3,72px)}
+    .dpad button{width:72px;height:72px;font-size:29px;border-radius:14px}
     .buttons{flex-direction:row}
-    .buttons button{width:80px;height:60px;font-size:20px}
+    .buttons button{width:96px;height:72px;font-size:24px;border-radius:24px}
+    .btn{font-size:120%}
+    #shopItems button,#bagItems button,#spellItems button{padding:12px;font-size:22px}
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Enlarge controller and UI buttons by 20% on mobile screens
- Add pointer cursor to buttons for clearer tap feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83c0791dc8330a0a8122cbba097fc