### PR TITLE
Keep controller split layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,9 @@
   #shopItems button,#bagItems button,#spellItems button{display:block;width:100%;margin:6px 0;padding:10px;font-size:18px}
   @media screen and (max-width:700px){
     canvas{width:90vw;height:90vw}
-    .controller{flex-direction:column;align-items:center;gap:20px;padding:0 0 calc(env(safe-area-inset-bottom,0px)+20px)}
+    .controller{justify-content:space-between;gap:20px;padding:0 20px calc(env(safe-area-inset-bottom,0px)+20px)}
     .dpad{grid-template-columns:repeat(3,72px);grid-template-rows:repeat(3,72px)}
     .dpad button{width:72px;height:72px;font-size:29px;border-radius:14px}
-    .buttons{flex-direction:row}
     .buttons button{width:96px;height:72px;font-size:24px;border-radius:24px}
     .btn{font-size:120%}
     #shopItems button,#bagItems button,#spellItems button{padding:12px;font-size:22px}


### PR DESCRIPTION
## Summary
- Ensure on small screens the D-pad stays bottom-left and action buttons bottom-right by updating controller CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83e54c88c8330aa9ff64ed6787af8